### PR TITLE
TX-265: Multiple Tags

### DIFF
--- a/pytest_reportportal/service.py
+++ b/pytest_reportportal/service.py
@@ -627,17 +627,23 @@ class PyTestServiceClass(with_metaclass(Singleton, object)):
                 # pytest < 3.6
                 marker = item.keywords.get(keyword)
 
-            return "{}:{}".format(keyword, marker.args[0]) \
-                if marker and marker.args else keyword
+            marker_values = []
+            if marker and marker.args:
+                for arg in marker.args:
+                    marker_values.append("{}:{}".format(keyword, arg))
+            else:
+                marker_values.append(keyword)
+            return marker_values  # returns a list of strings to accommodate multiple tags
 
         try:
             get_marker = getattr(item, "get_closest_marker")
         except AttributeError:
             get_marker = getattr(item, "get_marker")
 
-        raw_attrs = [get_marker_value(item, k)
-                     for k in item.keywords if get_marker(k) is not None
-                     and k not in self.ignored_attributes]
+        raw_attrs = []
+        for k in item.keywords:
+            if get_marker(k) is not None and k not in self.ignored_attributes:
+                raw_attrs.extend(get_marker_value(item, k))
         raw_attrs.extend(item.session.config.getini('rp_tests_attributes'))
         return get_attributes(raw_attrs)
 


### PR DESCRIPTION
All test functions will be modified by Pytest-Owl to have 1 Marker with all unique tags as `args`.

This PR will allow the Pytest agent to send multiple `args` as part of the test, rather than just `arg[0]`.


Ex: The following test
```
@pytest.mark.tags(Product().Designer.DesignObjects.Folder)
@pytest.mark.tags(Product().Designer.DesignObjects.Interface)
def test_that_uses_folder_and_interface(self):
	assert True
```

will send these tags to ReportPortal
```
tags:Designer
tags:DesignObjects
tags:Folder
tags:Interface
```
